### PR TITLE
Doc/templates structures

### DIFF
--- a/.github/workflows/build-sphinx-docs.yml
+++ b/.github/workflows/build-sphinx-docs.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Build Templates Page
         run: |
-          python generate_templates_docs.py
+          python ./doc/source/generate_templates_docs.py
 
       - name: Build Documentation
         run: |

--- a/.github/workflows/build-sphinx-docs.yml
+++ b/.github/workflows/build-sphinx-docs.yml
@@ -15,6 +15,10 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Build Templates Page
+        run: |
+          python generate_templates_docs.py
+
       - name: Build Documentation
         run: |
           pip install -r requirements_doc.txt --disable-pip-version-check

--- a/.github/workflows/deploy-sphinx-docs.yml
+++ b/.github/workflows/deploy-sphinx-docs.yml
@@ -18,6 +18,10 @@ jobs:
         with:
           python-version: 3.9
 
+      - name: Build Templates Page
+        run: |
+          python generate_templates_docs.py
+
       - name: Build Documentation
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/deploy-sphinx-docs.yml
+++ b/.github/workflows/deploy-sphinx-docs.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Build Templates Page
         run: |
-          python generate_templates_docs.py
+          python ./doc/source/generate_templates_docs.py
 
       - name: Build Documentation
         run: |

--- a/doc/source/generate_templates_docs.py
+++ b/doc/source/generate_templates_docs.py
@@ -15,9 +15,9 @@ def parse_directory_into_string(directory: pathlib.Path, indent=1):
     return '\n'.join(strings)
 
 
-project_dir = pathlib.Path(os.path.dirname(__file__))
-templates = project_dir / 'src' / 'templates'
-templates_md = project_dir / 'doc' / 'source' / 'templates_.md'
+source_dir = pathlib.Path(os.path.dirname(__file__))
+templates = source_dir.parent.parent / 'src' / 'templates'
+templates_md = source_dir / 'templates_.md'
 
 sections = []
 for t in templates.iterdir():

--- a/doc/source/templates.rst
+++ b/doc/source/templates.rst
@@ -9,5 +9,10 @@ In General
 The details of which templates are currently available (and the files included) are shown below.
 This list is generated from the templates available in the latest release.
 
+Note: The "shared" template is not an actual template but a directory of files that is copied to
+every template (hence "shared"). The only exceptions are that slightly different directory
+structures are used for the CI/CD workflows depending on if you selected GitHub or ADO for your
+CI/CD when you created your project.
+
 .. mdinclude :: ./templates_.md
 

--- a/doc/source/templates.rst
+++ b/doc/source/templates.rst
@@ -6,18 +6,8 @@ Templates
 In General
 ----------
 
-shared
-______
+The details of which templates are currently available (and the files included) are shown below.
+This list is generated from the templates available in the latest release.
 
-classic
--------
-
-rest-api
---------
-
-package
--------
-
-gRPC-api
---------
+.. mdinclude :: ./templates_.md
 

--- a/doc/source/templates_.md
+++ b/doc/source/templates_.md
@@ -1,0 +1,1 @@
+ERROR: Templates could not be built.

--- a/generate_templates_docs.py
+++ b/generate_templates_docs.py
@@ -1,0 +1,32 @@
+import pathlib
+import os
+
+
+def parse_directory_into_string(directory: pathlib.Path, indent=1):
+    strings = []
+    for file in directory.iterdir():
+        if file.is_dir():
+            result = parse_directory_into_string(file, indent+1)
+            string = f'\u2570-- {file.name}/\n' + '|   ' * indent + f'{result}'
+        else:
+            string = f'\u2570-- {file.name}'
+        strings.append(string)
+
+    return '\n'.join(strings)
+
+
+project_dir = pathlib.Path(os.path.dirname(__file__))
+templates = project_dir / 'src' / 'templates'
+templates_md = project_dir / 'doc' / 'source' / 'templates_.md'
+
+sections = []
+for t in templates.iterdir():
+    if t.is_dir():
+        title = f'## {t.name}'
+        s = parse_directory_into_string(t)
+        section = f'{title}\n\n```\n{s}\n```\n\n'
+        sections.append(section)
+
+doc = '\n'.join(sections)
+with open(templates_md, 'w', encoding='utf-8') as f:
+    f.write(doc)


### PR DESCRIPTION
Added script to root of repo (it shouldn't be included in any build and
should not otherwise be available to users) that when triggered builds a
new markdown file in the source of the docs, with details of all the
current templates available.

Added a trigger for this when the docs are built.

Closes #42 