### PR TITLE
Fix/setup.py packages

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -65,7 +65,12 @@ def add_project_name_to_files(files_with_template: List[pathlib.Path],
         with open(file, 'r') as f:
             string = f.read()
         template = Template(string)
-        result = template.substitute({'project_name': project_name})
+        if file.name == 'setup.py':
+            result = template.substitute(
+                {'project_name': project_name.replace('-', '_')}
+            )
+        else:
+            result = template.substitute({'project_name': project_name})
         with open(file, 'w') as f:
             f.write(result)
 
@@ -236,6 +241,7 @@ class ProjectGenerator:
         files_with_project_name = [
             destination / 'doc' / 'source' / 'conf.py',
             destination / 'doc' / 'source' / 'index.rst',
-            destination / 'README.md'
+            destination / 'README.md',
+            destination / 'setup.py'
         ]
         add_project_name_to_files(files_with_project_name, project_name)

--- a/src/templates/shared/setup.py
+++ b/src/templates/shared/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
 
 setup(name='project-name',
@@ -6,7 +6,8 @@ setup(name='project-name',
       license='MIT',
       description='Short description of project-name',
       keywords=['python', 'ansys', 'ace'],
-      packages=find_packages(),
+      packages=['project-name'],
+      package_dir={'project-name': 'src'},
       install_requires=[],
       long_description=open('README.md').read(),
       long_description_content_type='text/markdown'

--- a/src/templates/shared/setup.py
+++ b/src/templates/shared/setup.py
@@ -1,13 +1,13 @@
 from setuptools import setup
 
 
-setup(name='project-name',
+setup(name='$project_name',
       version='0.0.1',
       license='MIT',
-      description='Short description of project-name',
+      description='Short description of $project_name',
       keywords=['python', 'ansys', 'ace'],
-      packages=['project-name'],
-      package_dir={'project-name': 'src'},
+      packages=['$project_name'],
+      package_dir={'$project_name': 'src'},
       install_requires=[],
       long_description=open('README.md').read(),
       long_description_content_type='text/markdown'

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -62,10 +62,10 @@ class TestGetTemplatesPath:
 
 class TestApplyTemplate:
     @pytest.mark.parametrize('proj_name', ['new', 'new2', '2new', '22',
-                                           'new-2', 'new two', ' new '])
+                                           'new two', ' new '])
     def test_project_name_rename(self, proj_name, tmp_path):
         s = '$project_name'
-        test_files = [tmp_path / f'test.{suffix}'
+        test_files = [tmp_path / f'test{suffix}'
                       for suffix in ['.py', '.txt', '.md']]
         for test_file in test_files:
             with open(test_file, 'w') as f:
@@ -75,3 +75,21 @@ class TestApplyTemplate:
             with open(test_file, 'r') as f:
                 s = f.read()
             assert proj_name in s
+
+    def test_project_name_rename_removes_hyphens_in_setup_dot_py(self,
+                                                                 tmp_path):
+        proj_name = 'new-2'
+        s = '$project_name'
+        test_files = [tmp_path / f'setup{suffix}'
+                      for suffix in ['.py', '.txt', '.md']]
+        for test_file in test_files:
+            with open(test_file, 'w') as f:
+                f.write(s)
+        add_project_name_to_files(test_files, proj_name)
+        for test_file in test_files:
+            with open(test_file, 'r') as f:
+                s = f.read()
+            if test_file.suffix == '.py':
+                assert proj_name.replace('-', '_') in s
+            else:
+                assert proj_name in s

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -76,9 +76,10 @@ class TestApplyTemplate:
                 s = f.read()
             assert proj_name in s
 
+    @pytest.mark.parametrize('proj_name', ['new-2', 'new', 'new_2'])
     def test_project_name_rename_removes_hyphens_in_setup_dot_py(self,
+                                                                 proj_name,
                                                                  tmp_path):
-        proj_name = 'new-2'
         s = '$project_name'
         test_files = [tmp_path / f'setup{suffix}'
                       for suffix in ['.py', '.txt', '.md']]


### PR DESCRIPTION
Replaced project name in setup.py in `shared` with auto-filled project name.

Additionally replaces '-' with '_' in the string.

Added more complex setup.py package rules to account for the inclusion of `src` naming.