### PR TITLE
Fix/templates overwrite shared

### DIFF
--- a/src/generator.py
+++ b/src/generator.py
@@ -39,6 +39,8 @@ def copy_directory_and_contents_to_new_location(source: pathlib.Path,
     :param just_files: set True if only files should be copied to the new location.
     """
     logger.debug(f'Attempting to copy {source} to {target}')
+    if not target.is_dir():
+        os.makedirs(target, exist_ok=True)
     if just_files:
         logger.debug('Excluding directories from copy')
         for file in source.iterdir():
@@ -204,10 +206,7 @@ class ProjectGenerator:
         """
         ProjectTemplateAndDestinationChecker(self.template,
                                              destination).check()
-        copy_directory_and_contents_to_new_location(
-            self.template.template_directory,
-            destination
-        )
+
         if self.template.shared_files_directory is not None:
             copy_directory_and_contents_to_new_location(
               self.template.shared_files_directory,
@@ -226,6 +225,10 @@ class ProjectGenerator:
                               / 'cicd' / 'azure-pipelines.yml'
             os.makedirs(cicd_target, exist_ok=True)
             shutil.copy(cicd_source, cicd_target / file_name)
+        copy_directory_and_contents_to_new_location(
+            self.template.template_directory,
+            destination
+        )
         rename_files_in_directory(destination)
 
         logger.info(emoji.emojize('Project created successfully :thumbs_up:  '

--- a/src/templates/rest-api/requirements.txt
+++ b/src/templates/rest-api/requirements.txt
@@ -1,0 +1,5 @@
+setuptools>=41.0.0
+wheel>=0.33.0
+flask
+flask-cors
+flask-swagger-ui

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -51,6 +51,15 @@ class TestGenerateProjectFolder:
         pg = ProjectGenerator(builtin_templates[name])
         pg.generate_template_at_destination(destination_directory)
 
+    def test_requirements_overwrites_in_rest_api(self,
+                                                 builtin_templates,
+                                                 destination_directory):
+        pg = ProjectGenerator(builtin_templates['rest-api'])
+        pg.generate_template_at_destination(destination_directory)
+        with open(destination_directory / 'requirements.txt', 'r') as f:
+            contents = f.read()
+            assert 'flask' in contents
+
     def test_shared_template_fails(self, builtin_templates_path, destination_directory):
         with pytest.raises(ValueError):
             pt = ProjectTemplate(builtin_templates_path / 'shared', builtin_templates_path / 'shared')


### PR DESCRIPTION
All files in the template dir now overwrite those in the shared folder
(they are put in the project second). This is so that templates can have
template-specific versions of files. E.g. rest-api has different
requirements including flask.