### PR TITLE
Added entry points to setup.py

### DIFF
--- a/.github/workflows/build-sphinx-docs.yml
+++ b/.github/workflows/build-sphinx-docs.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Build Documentation
         run: |
+          pip install -r requirements.txt --disable-pip-version-check
           pip install -r requirements_doc.txt --disable-pip-version-check
           cd doc/
           make html

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@
 Easily create a new Python project with simple commands:
 
 ```shell
-pipx run acpp -n my-project
+pipx run ansys-create-python-project -n my-project
 ```
 or
 
 ```shell
-python -m acpp -n my-project
+acpp -n my-project
 ```
 
 <h1 align="center">
@@ -49,7 +49,7 @@ This tool is compatible with Windows OS and Linux distributions.
 #### With pipx
 
 ```shell
-pipx run acpp -n my-project 
+pipx run ansys-create-python-project -n my-project 
 ```
 
 [pipx](https://pypa.github.io/pipx/) is a package runner tool that that helps to run applications written in Python.
@@ -99,16 +99,16 @@ If you do not want to install pipx you can still use the package, but first you 
 ```shell
 pip install ansys-create-python-project
 ```
-Then, you can run the package using Python's `python -m` functionality.
+Then, you can run the package on the command line.
 
 ```shell
-python -m acpp -n my-project
+acpp -n my-project
 ```
 
 If you aren't sure what sort of arguments you need to supply you can always view the help through the following command.
 
 ```shell
-python -m acpp --help
+acpp --help
 ```
 
 #### Specify other templates
@@ -117,13 +117,13 @@ The default project template is 'classic'. However, there are several other temp
 You can view the available templates by running the following command.
 
 ```shell
-pipx run acpp --template
+pipx run ansys-create-python-project --template
 ```
 
 You can easily specify other templates with the `-t` flag.
 
 ```sh
-pipx run acpp -n my-project -t rest-api
+pipx run ansys-create-python-project -n my-project -t rest-api
 ```
 
 ### Run tests locally

--- a/doc/source/examples.rst
+++ b/doc/source/examples.rst
@@ -22,7 +22,7 @@ The minimum you need to provide is the name of your project using either the ``-
 
 .. code-block:: powershell
 
-    PS C:\> python -m acpp -n my_project
+    PS C:\> acpp -n my_project
     12:57:50 [INFO] Project created successfully
     We recommend you track your project using git
     and store it in a remote repository, such as on ADO or GitHub.
@@ -74,7 +74,7 @@ the :ref:`Templates`. page. If you want to view those available to you you can a
 
 .. code-block:: powershell
 
-    PS C:\> python -m acpp --templates
+    PS C:\> acpp --templates
     Available templates are:
      * classic
      * gRPC-api
@@ -101,7 +101,7 @@ For example, to create a new package called "my_package", you would need to exec
 
 .. code-block:: powershell
 
-    PS C:\> python -m acpp -n my_package -t package
+    PS C:\> acpp -n my_package -t package
     11:56:59 [INFO] Project created successfully
     We recommend you track your project using git
     and store it in a remote repository, such as on ADO or GitHub.
@@ -151,7 +151,7 @@ If you're still having trouble understanding the command line, you can always vi
 
 .. code-block:: powershell
 
-    PS C:\> python -m acpp --help
+    PS C:\> acpp --help
     usage: __main__.py [-h] [-n NAME] [-t TEMPLATE] [--templates] [--version] [--cicd CICD]
 
     optional arguments:

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -3,3 +3,5 @@ sphinx_mdinclude
 pyansys-sphinx-theme
 numpydoc
 sphinx_autodoc_typehints
+coloredlogs~=15.0.1
+

--- a/requirements_doc.txt
+++ b/requirements_doc.txt
@@ -3,5 +3,4 @@ sphinx_mdinclude
 pyansys-sphinx-theme
 numpydoc
 sphinx_autodoc_typehints
-coloredlogs~=15.0.1
 

--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,14 @@ setup(name='ansys-create-python-project',
       license='MIT',
       description='Ansys Python Project Creator',
       keywords=['python', 'ansys', 'ace'],
-      packages=['acpp'],
-      package_dir={'acpp': 'src'},
+      packages=['ansys_create_python_project'],
+      package_dir={'ansys_create_python_project': 'src'},
+      entry_points={
+          'console_scripts': [
+              'ansys-create-python-project=ansys_create_python_project:cli',
+              'acpp=ansys_create_python_project:cli',
+          ]
+      },
       install_requires=['coloredlogs~=15.0.1','emoji~=1.6.3'],
       long_description=open('README.md').read(),
       long_description_content_type='text/markdown',

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,1 @@
+from .main import cli


### PR DESCRIPTION
Pipx was failing because we added the alias of acpp for pure pip users,
which also broke pipx (which needs the package and the run command to be
the same).

This fix implements entry points to setup.py. Now pip users do not even
need to specify the "python -m" and can just invoke "acpp --help"
directly. But it re-adds the capability to run the tool with
"ansys-create-python-project", as pipx requires. I have not been able to
test this beyond a local pipx execution (which worked). We need to push
to PyPI first. It might be worth pushing to testpypi? I'm not sure. It
can be tricky getting pipx to work with that. Given our userbase is
relatively small, it might just be OK to push to PyPI and fix it up
relatively quickly.

I have also altered the documentation to represent what should be
working and the new syntax.

fixes #56 