### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@
   <a href="#license"><img src="https://img.shields.io/github/license/sourcerer-io/hall-of-fame.svg?colorB=ff0000"></a>
 </p>
 
+## Deprecation Warning
+
+> **Warning**
+**This repository has been deprecated in favor of [ansys-templates].** The
+new template takes advantage of a dynamic install, allows you to select the
+build system and is deeply tested.
+
+[ansys-templates]: https://github.com/ansys/ansys-templates
+
+
 ## Quick Overview
 
 Easily create a new Python project with simple commands:


### PR DESCRIPTION
Solves #88 by adding a deprecation warning at the very top of the `README.md` file. Once merged, this repository can be archived as it was made with [pyansys/template](https://github.com/pyansys/template/).